### PR TITLE
Fix gjmbH Zeeman index bug in ic1ion standalone

### DIFF
--- a/bin/ic1ion_module/ic1ion.cpp
+++ b/bin/ic1ion_module/ic1ion.cpp
@@ -393,8 +393,8 @@ int main(int argc, char *argv[])
    {
       std::vector<double> gjmbH(6,0.);
       if(fabs(pars.Bx)>DBL_EPSILON) { gjmbH[3]=-MUBc*pars.Bx; gjmbH[0]=GS*gjmbH[3]; }
-      if(fabs(pars.By)>DBL_EPSILON) { gjmbH[4]=-MUBc*pars.By; gjmbH[2]=GS*gjmbH[4]; }
-      if(fabs(pars.Bz)>DBL_EPSILON) { gjmbH[5]=-MUBc*pars.Bz; gjmbH[4]=GS*gjmbH[5]; }
+      if(fabs(pars.By)>DBL_EPSILON) { gjmbH[4]=-MUBc*pars.By; gjmbH[1]=GS*gjmbH[4]; }
+      if(fabs(pars.Bz)>DBL_EPSILON) { gjmbH[5]=-MUBc*pars.Bz; gjmbH[2]=GS*gjmbH[5]; }
       sMat<double> J,iJ; icmfmat mfmat(pars.n,pars.l,6,pars.save_matrices); mfmat.Jmat(J,iJ,gjmbH); Hic+=J; iHic+=iJ;
    }
 


### PR DESCRIPTION
Lines 396-397 had wrong spin-coupling indices: gjmbH[2] was set for By (should be gjmbH[1]) and gjmbH[4] was overwritten by the Bz branch (should write to gjmbH[2]). This produced wrong eigenvalues for any magnetic field with both By and Bz components.

The correct mapping (matching ic_cmag lines 291-293) is:
  gjmbH[0]=GS*Hx, gjmbH[1]=GS*Hy, gjmbH[2]=GS*Hz  (spin)
  gjmbH[3]=Hx,    gjmbH[4]=Hy,    gjmbH[5]=Hz       (orbital)