### PR TITLE
Fix graphic_parameters constructor overwriting grid values from file

### DIFF
--- a/bin/src/graphic_parameters.cpp
+++ b/bin/src/graphic_parameters.cpp
@@ -29,10 +29,10 @@ phonon_wave_amplitude=0;
 threshhold=0.05;
 density_dtheta=0.2;
 density_dfi=0.2;
-read();
 gridi=30;
 gridj=30;
 gridk=30;
+read();
 }
 
 int graphic_parameters::read()


### PR DESCRIPTION
The constructor called read() then unconditionally set gridi/gridj/gridk to 30, ignoring any values loaded from results/graphic_parameters.set. Move the defaults before read() so file values take precedence.