### PR TITLE
Fix fediff spinchange to use actual old-new spin difference

### DIFF
--- a/bin/src/fediff.c
+++ b/bin/src/fediff.c
@@ -201,6 +201,7 @@ double fecalc(Vector Hex, double T, par &inputpars, spincf &sps, mfcf &mf, doubl
             for(k=1;k<=sps.nc();++k)
             {
                s=sps.in(i,j,k);
+               diff=sps.m(i,j,k);
                for(l=1;l<=inputpars.nofatoms;++l)
                {
                   int lm1m3;


### PR DESCRIPTION
spinchange was computed using diff left over from the MF update step (diff = (mf-mfold)*stepratio), not the actual spin change. Save the old spin sps.m(i,j,k) into diff before Icalc overwrites it, so that diff -= sps.m(i,j,k) afterwards gives |old - new|.