### PR TITLE
Remove spurious 1e-200 offset from vector Norm()

### DIFF
--- a/bin/src/vector/dvector.cc
+++ b/bin/src/vector/dvector.cc
@@ -750,7 +750,7 @@ double Norm (const Vector &A)
 {
   int n = A.Elements();
   if (n <= 0) Matpack.Error("double Norm (const Vector &A) -- empty vector");
-  double sum = sqrt(norm2(A.Store(),n)+1e-200);
+  double sum = sqrt(norm2(A.Store(),n));
   return sum;
 }
 


### PR DESCRIPTION
Norm() computed sqrt(norm2 + 1e-200), which made a zero-length vector report magnitude 1e-100 instead of 0. This affected density outputs (densplt and others) that rely on Norm() for absolute values.