### PR TITLE
Fix density surface duplicate-minimum check using bitwise & instead o…

### DIFF
--- a/bin/src/density.cpp
+++ b/bin/src/density.cpp
@@ -100,7 +100,7 @@ for(tt=0;tt<=3.1415/dtheta;++tt){for(ff=0;ff<=2*3.1415/dfi;++ff){
                      }
      }
      if(delta1<max)
-     {for(iv=1;(iv<=nt)&(fabs(rp(iv)-R)>=0.1);++iv){;}// check if this minimum was already stored
+     {for(iv=1;(iv<=nt)&&(fabs(rp(iv)-R)>=0.1);++iv){;}// check if this minimum was already stored
       if(fabs(rp(iv)-R)>=0.1) // if not store it (up to nt=imax minima will be stored)
        {++nt;rp(nt)=R;
         if (R>rmax)rmax=R;


### PR DESCRIPTION
…f &&

The for loop condition used bitwise & which does not short-circuit, causing rp(nt+1) (zero-initialized) to be read even when iv>nt. This made any candidate minimum with |R|<0.1 appear as a duplicate of the implicit zero entry, suppressing valid near-zero minima.