### PR TITLE
Fix bfk mode 7 using global kapv instead of local qq for kapnv

### DIFF
--- a/bin/bfk_src/bfk.f95
+++ b/bin/bfk_src/bfk.f95
@@ -1621,7 +1621,7 @@ if (mode==7) then
       ks=sqrt(ksks) 
       kappa=sqrt(qq(1)*qq(1)+qq(2)*qq(2) +qq(3)*qq(3))
       do i=1,3
-        kapnv(i)=kapv(i)/kappa
+        kapnv(i)=qq(i)/kappa
        end do
        if (w7==1) then
          st=strfak(kappa)


### PR DESCRIPTION
Line 1624 computed kapnv from kapv (a global read from the scatter file) divided by kappa (computed from the local qq vector). This mismatch made the scattering direction vector inconsistent. Use qq consistently, matching how kappa is computed on line 1622.