### PR TITLE
Fix M_parallel field-direction indices in ic_cmag

### DIFF
--- a/bin/ic1ion_module/ic1ion.cpp
+++ b/bin/ic1ion_module/ic1ion.cpp
@@ -332,15 +332,15 @@ void ic_cmag(const char *filename, icpars &pars, double elim)
          for(j=0; j<nT; j++) 
             FILEOUT << T[j] << "\t" << Hm*pars.yHa << "\t" << Hm*pars.yHb << "\t" << Hm*pars.yHc << "\t" << mag[j]*convfact
                     << "   \t" << ma[j]*convfact << "   \t" << mb[j]*convfact << "   \t" << mc[j]*convfact << "   \t"
-                    << (ma[j]*gjmbH[1] + mb[j]*gjmbH[3] + mc[j]*gjmbH[5])*convfact << "\n";
+                    << (ma[j]*gjmbH[3] + mb[j]*gjmbH[4] + mc[j]*gjmbH[5])*convfact << "\n";
       }
       else
       {
          Hm = (Hmin+i*Hstep)/xnorm;
-         for(j=0; j<nT; j++) 
+         for(j=0; j<nT; j++)
             FILEOUT << Hm*pars.xHa << "\t" << Hm*pars.xHb << "\t" << Hm*pars.xHc << "\t" << T[j] << "\t" << mag[j]*convfact
-                    << "   \t" << ma[j]*convfact << "   \t" << mb[j]*convfact << "   \t" << mc[j]*convfact << "   \t" 
-                    << (ma[j]*gjmbH[1] + mb[j]*gjmbH[3] + mc[j]*gjmbH[5])*convfact << "\n";
+                    << "   \t" << ma[j]*convfact << "   \t" << mb[j]*convfact << "   \t" << mc[j]*convfact << "   \t"
+                    << (ma[j]*gjmbH[3] + mb[j]*gjmbH[4] + mc[j]*gjmbH[5])*convfact << "\n";
       }
    }
 }


### PR DESCRIPTION
The M_parallel projection used gjmbH[1],gjmbH[3],gjmbH[5] which mixes spin-coupling (GS-scaled) and orbital-coupling indices across the wrong axes: ma was dotted with GS*Hb, mb with Ha, mc with Hc.

The correct dot product with the field unit vector uses the orbital indices gjmbH[3],gjmbH[4],gjmbH[5] = Ha/|H|, Hb/|H|, Hc/|H|. This was already correct for single-axis fields by coincidence.