### PR TITLE
Fix cpso1ion.pl undefined variable and wrong temperature output

### DIFF
--- a/bin/cpso1ion.pl
+++ b/bin/cpso1ion.pl
@@ -118,7 +118,7 @@ $ii=0;$sta=0;
 
 # read temperatures and calculate cp + comp to experiment
 
-  print  "# T(K)  $cptext  exp-$cpctext\n";
+  print  "# T(K)  $cptext  exp-$cptext\n";
 
   while($line=<Fin>)
 
@@ -138,7 +138,7 @@ $ii=0;$sta=0;
 
 	 $sta+=($cpclc-$cpexp)*($cpclc-$cpexp);
 
-         print   "$T $cpclc $cpexp\n";
+         print   "$T0 $cpclc $cpexp\n";
 
         }
 


### PR DESCRIPTION
Line 121: $cpctext was never defined — typo for $cptext. The comparison header printed "exp-" instead of "exp-cp(J/molK)".

Line 141: $T was used instead of $T0. The cp() subroutine sets $T = $T0 - dT/2 before returning, so the printed temperature was off by 0.05K. The other code path (line 163) correctly used $T0.