### PR TITLE
Use "delete[]" after "new[]", not "delete"

### DIFF
--- a/bin/src/jjjpar.cpp
+++ b/bin/src/jjjpar.cpp
@@ -282,7 +282,7 @@ int  jjjpar::addpar (Vector & dabc,Vector & drijk,int & subl)
   delete []jijn;
   delete []dnn;
   delete []drr;
-  delete sl;
+  delete []sl;
   return paranz;
 }
 
@@ -386,7 +386,7 @@ void jjjpar::sortpars ()
   delete []jijn;
   delete []dnn;
   delete []drr;
-  delete sl;
+  delete []sl;
 
 }
 

--- a/bin/src/vector/cvector.cc
+++ b/bin/src/vector/cvector.cc
@@ -304,7 +304,7 @@ void ComplexVector::Resize (int ncl, int nch)
 	    if ((csize = nch-ch)  > 0) copyval(v+hi+1,Zero,csize);
 
 	    // remove old vector
-	    delete (V+cl);
+	    delete[] (V+cl);
 
 	} else {  // newly initialized vector
 	    

--- a/bin/src/vector/dmatrix.cc
+++ b/bin/src/vector/dmatrix.cc
@@ -371,8 +371,8 @@ void Matrix::Resize (int nrl, int nrh, int ncl, int nch)
 #endif
 	
 	// remove old matrix
-	delete (M[rl]+cl);
-	delete (M+rl);
+	delete[] (M[rl]+cl);
+	delete[] (M+rl);
 	
 	
     } else {  // newly initialized matrix

--- a/bin/src/vector/dvector.cc
+++ b/bin/src/vector/dvector.cc
@@ -290,7 +290,7 @@ void Vector::Resize (int ncl, int nch)
 	    if ((csize = nch-ch)  > 0) copyval(v+hi+1,Zero,csize);
 
 	    // remove old vector
-	    delete (V+cl);
+	    delete[] (V+cl);
 
 	} else {  // newly initialized vector
 	    

--- a/bin/src/vector/imatrix.cc
+++ b/bin/src/vector/imatrix.cc
@@ -191,8 +191,8 @@ IntMatrix::~IntMatrix (void)
 	if ( (--(D->count) == 0 && temporary == 0) || D->count < 0) {
 
 	    // free data
-	    delete (M[rl]+cl);
-	    delete (M+rl);
+	    delete[] (M[rl]+cl);
+	    delete[] (M+rl);
 
 	    // free info block
 	    delete D;
@@ -259,8 +259,8 @@ void IntMatrix::Resize (int nrl, int nrh, int ncl, int nch)
 #endif
 	
 	// remove old matrix
-	delete (M[rl]+cl);
-	delete (M+rl);
+	delete[] (M[rl]+cl);
+	delete[] (M+rl);
 	
 	
     } else {  // newly initialized matrix

--- a/bin/src/vector/ivector.cc
+++ b/bin/src/vector/ivector.cc
@@ -224,7 +224,7 @@ void IntVector::Resize (int ncl, int nch)
 	    if ((csize = nch-ch)  > 0) copyval(v+hi+1,Zero,csize);
 
 	    // remove old vector
-	    delete (V+cl);
+	    delete[] (V+cl);
 
 	} else {  // newly initialized vector
 	    


### PR DESCRIPTION
Allowed:
```
p = new X[5];
delete[] p;
```

Not allowed--can cause heap corruption:
```
p = new X[5];
delete p;
```

This PR fixes this problem.